### PR TITLE
Moving ELF parser to kernel

### DIFF
--- a/include/uapi/linux/elf.h
+++ b/include/uapi/linux/elf.h
@@ -354,6 +354,7 @@ typedef struct elf64_shdr {
 
 #define ELFOSABI_NONE	0
 #define ELFOSABI_LINUX	3
+#define ELFOSABI_HERMIT	0x42
 
 #ifndef ELF_OSABI
 #define ELF_OSABI ELFOSABI_NONE


### PR DESCRIPTION
This way we can get rid of the temporary file /tmp/hermitXXXXXX

Maybe this is a first step to have a pure shell based proxy or
no need for a proxy at all.
